### PR TITLE
pins primereact to work around incompatability in FilePicker.tsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "debug": "^4.3.4",
     "monaco-editor": "^0.36.1",
     "primeicons": "^6.0.1",
-    "primereact": "^9.2.1",
+    "primereact": "9.3.x",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-stl-viewer": "^2.2.5",


### PR DESCRIPTION
Fixes #3 

In primereact 9.4.0+ an incompatibility was created in how this repo uses the FilePicker component resulting in an unusable build

This pull request pins the primereact dependency to the latest compatible version (9.3.1). Long term, the project should either refactor the use of the FilePicker or move to a component library that respects SemVer.