### PR TITLE
Filename based download

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Licenses: see [LICENSES](./LICENSE).
 - Rebuild w/ (and sync) ochafik@'s filtered kernel (https://github.com/openscad/openscad/pull/4160) to fix(ish) 2D operations
 - Replace Makefile w/ something that reads the libs metadata
 - Proper Preview rendering: have OpenSCAD export the preview scene to a rich format (e.g. glTF, with some parts being translucent when prefixed w/ % modifier) and display it using https://modelviewer.dev/ maybe)
-- Better names for downloads (matching source)
 - Model /home fs in shared state. have two clear paths: /libraries for builtins, and /home for user data. State pointing to /libraries paths needs not store the data except if there's overrides (flagged as modifications in the file picker)
 - Drag and drop of files (SCAD, STL, etc) and Zip archives. For assets, auto insert the corresponding import.
 - Fuller PWA support w/ link Sharing, File opening / association to *.scad files... 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,8 +15,9 @@ import { confirmDialog } from 'primereact/confirmdialog';
 
 function downloadOutput(state: State) {
   if (!state.output) return;
-
-  const fileName = state.output!.isPreview ? 'preview.stl' : 'render.stl';
+  const sourcePathParts = state.params.sourcePath.split('/');
+  const sourceFileName = sourcePathParts.slice(-1)[0];
+  const fileName = [sourceFileName, state.output!.isPreview ? 'preview.stl' : 'render.stl'].join('.');
   const doDownload = () => {
     const a = document.createElement('a')
     a.href = state.output!.stlFileURL


### PR DESCRIPTION
Resolves roadmap item:

`Better names for downloads (matching source)`

Before this PR, a user would either get `render.stl` or `preview.stl` when clicking the download button which is not very helpful, especially if you are working on multiple files.

This PR changes the behaviour so the download filename is based on the the scad filename with a suffix. So, for example if you're working on `foo.scad` in preview mode the download will be `foo.scad.preview.stl`, likewise if the filename is `bar.scad` in render mode, the filename will be `bar.scad.render.stl`.  It is also aware of files in a directory tree, so if the filename is `/foo/bar/baz.scad` the resulting file would be `baz.scad.preview.stl`, etc. 

