### PR TITLE
🐛 fix cannot find ../wasm/openscad.js

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
+    "src/**/*.js",
     // "public"
   ]
 }


### PR DESCRIPTION
PR resolves the following error:

[1] [!] (plugin rpt2) Error: src/runner/openscad-worker.ts:3:22 - error TS2307: Cannot find module '../wasm/openscad.js' or its corresponding type declarations.

