### PR TITLE
Support & document using custom wasm build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ src/wasm: libs/openscad-wasm
 wasm: libs/openscad
 	( cd libs/openscad && ./scripts/wasm-base-docker-run.sh emcmake cmake -B build -DCMAKE_BUILD_TYPE=$(WASM_BUILD) -DEXPERIMENTAL=1 )
 	( cd libs/openscad && ./scripts/wasm-base-docker-run.sh /bin/bash -c "cmake --build build -j || cmake --build build -j2 || cmake --build build" )
-	( cd libs/openscad-wasm && unzip ../openscad-wasm.zip )
 	mkdir -p libs/openscad-wasm
 	cp libs/openscad/build/openscad.* libs/openscad-wasm/
 

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,11 @@ SINGLE_BRANCH=--branch master --single-branch
 SHALLOW=--depth 1
 
 SHELL:=/usr/bin/env bash
+WASM_BUILD=Release
 
 all: public
 
-.PHONY: public
+.PHONY: public wasm
 public: \
 		src/wasm \
 		public/openscad.js \
@@ -41,7 +42,7 @@ public: \
 clean:
 	rm -fR libs build
 	rm -fR public/openscad.{js,wasm}
-	rm -fR public/libraries
+	rm -fR public/libraries/*.zip
 	rm -fR src/wasm
 
 dist/index.js: public
@@ -54,13 +55,12 @@ src/wasm: libs/openscad-wasm
 	rm -f src/wasm
 	ln -sf "$(shell pwd)/libs/openscad-wasm" src/wasm
 
-# libs/openscad/build/openscad.js: libs/openscad
-# 	( cd libs/openscad && ./scripts/wasm-base-docker-run.sh emcmake cmake -B build -DCMAKE_BUILD_TYPE=Release -DEXPERIMENTAL=1 )
-# 	( cd libs/openscad && ./scripts/wasm-base-docker-run.sh /bin/bash -c "cmake --build build -j || cmake --build build -j2 || cmake --build build" )
-
-# libs/openscad-wasm: libs/openscad/build/openscad.js
-# 	mkdir -p libs/openscad-wasm
-# 	cp libs/openscad/build/openscad.* libs/openscad-wasm/
+wasm: libs/openscad
+	( cd libs/openscad && ./scripts/wasm-base-docker-run.sh emcmake cmake -B build -DCMAKE_BUILD_TYPE=$(WASM_BUILD) -DEXPERIMENTAL=1 )
+	( cd libs/openscad && ./scripts/wasm-base-docker-run.sh /bin/bash -c "cmake --build build -j || cmake --build build -j2 || cmake --build build" )
+	( cd libs/openscad-wasm && unzip ../openscad-wasm.zip )
+	mkdir -p libs/openscad-wasm
+	cp libs/openscad/build/openscad.* libs/openscad-wasm/
 
 libs/openscad-wasm:
 	mkdir -p libs/openscad-wasm

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ libs/openscad:
 
 public/libraries/openscad.zip: libs/openscad
 	mkdir -p public/libraries
-	( cd libs/openscad ; zip -r ../../public/libraries/openscad.zip `find examples -name '*.scad' | grep -v tests` )
+	( cd libs/openscad ; zip -r - `find examples -name '*.scad' | grep -v tests` ) > public/libraries/openscad.zip 
 
 libs/BOSL2: 
 	git clone --recurse https://github.com/BelfrySCAD/BOSL2.git ${SHALLOW} ${SINGLE_BRANCH} $@

--- a/README.md
+++ b/README.md
@@ -82,6 +82,33 @@ rm -fR ../ochafik.github.io/openscad2 && cp -R dist ../ochafik.github.io/opensca
 # Now commit and push changes, wait for site update and enjoy!
 ```
 
+## Build your own WASM binary
+
+[Makefile](./Makefile) fetches a prebuilt OpenSCAD web WASM binary, but you can build your own in a couple of minutes:
+
+- **Optional**: use your own openscad fork / branch:
+
+  ```bash
+  rm -fR libs/openscad
+  ln -s $PWD/../absolute/path/to/your/openscad libs/openscad
+  
+  # If you had a native build directory, delete it.
+  rm -fR libs/openscad/build
+  ```
+
+- Build WASM binary (add `WASM_BUILD=Debug` argument if you'd like to debug any cryptic crashes):
+
+  ```bash
+  make wasm
+  ```
+
+- Then continue the build:
+
+  ```bash
+  make public
+  npm start
+  ```
+
 ## Adding OpenSCAD libraries
 
 You'll need to update 3 files (search for BOSL2 for an example):


### PR DESCRIPTION
Useful to test a local branch of openscad or get a debug wasm build

```bash
# Optional: use existing openscad tree (and clear its build directory if it's configured for native builds)
#   rm -fR libs/openscad && ln -s $PWD/../openscad libs/openscad
#   rm -fR libs/openscad/build

make wasm WASM_BUILD=Debug
make public
npm start
```