### PR TITLE
Blurhash previews!

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "blurhash": "^2.0.5",
     "chroma-js": "^3.1.2",
     "debug": "^4.4.0",
     "jszip": "^3.10.1",
@@ -20,6 +21,7 @@
     "primereact": "^10.8.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "thumbhash": "^0.1.1",
     "uuid": "^11.0.3",
     "uzip": "^0.20201231.0"
   },

--- a/src/components/MultimaterialColorsDialog.tsx
+++ b/src/components/MultimaterialColorsDialog.tsx
@@ -40,11 +40,11 @@ export default function MultimaterialColorsDialog() {
                     <Button 
                     label={state.view.extruderPickerVisibility == 'exporting' ? "Export" : "Save"}
                     icon="pi pi-check"
-                    disabled={!tempExtruderColors.every(c => chroma.valid(c))}
+                    disabled={!tempExtruderColors.every(c => chroma.valid(c) || c.trim() === '')}
                     autoFocus
                     onClick={e => {
                         model!.mutate(s => {
-                            s.params.extruderColors = tempExtruderColors;
+                            s.params.extruderColors = tempExtruderColors.filter(c => c.trim() !== '');
                             s.view.extruderPickerVisibility = undefined;
                         });
                         if (state.view.extruderPickerVisibility === 'exporting') {
@@ -84,9 +84,9 @@ export default function MultimaterialColorsDialog() {
                                         }
                                     }}
                                     onChange={(e) => {
-                                        let color = e.target.value;
+                                        let color = e.target.value.trim();
                                         try {
-                                            color = chroma(e.target.value).name();
+                                            color = chroma(color).name();
                                             console.log(`color: ${e.target.value} -> ${color}`);
                                         } catch (e) {
                                             // ignore

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -40,7 +40,7 @@ export default function SettingsMenu({className, style}: {className?: string, st
           // disabled: true,
           command: () => model.mutate(s => s.view.lineNumbers = !s.view.lineNumbers)
         },
-        ...(isInStandaloneMode ? [
+        ...(isInStandaloneMode() ? [
           {
             separator: true
           },  

--- a/src/io/image_hashes.ts
+++ b/src/io/image_hashes.ts
@@ -1,0 +1,77 @@
+// Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
+
+import { rgbaToThumbHash, thumbHashToRGBA } from 'thumbhash'
+import { decode as decodeBlurHash, encode as encodeBlurHash } from "blurhash";
+
+async function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = (...args) => reject(args);
+    img.src = src;
+  });
+}
+
+export async function imageToBlurhash(imageUrl: string): Promise<string> {
+  const {rgba, w, h} = await getImageThumbnail(imageUrl, {maxSize: 100, opaque: true});
+  const parts = 9;
+  // const parts = 6;
+  return encodeBlurHash(new Uint8ClampedArray(rgba), w, h, parts, parts);
+}
+
+export async function imageToThumbhash(imagePath: string): Promise<string> {
+  const {rgba, w, h} = await getImageThumbnail(imagePath, {maxSize: 100, opaque: false});
+  const hash = rgbaToThumbHash(w, h, rgba);
+  return btoa(String.fromCharCode(...hash));
+}
+
+export function blurHashToImage(hash: string, width: number, height: number): string {
+  const pixels = decodeBlurHash(hash, width, height);
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d")!;
+  const imageData = ctx.createImageData(width, height);
+  imageData.data.set(pixels);
+  ctx.putImageData(imageData, 0, 0);
+  return canvas.toDataURL("image/png");
+}
+
+export function thumbHashToImage(hash: string): string {
+  const {w: width, h: height, rgba} = thumbHashToRGBA(new Uint8Array([...atob(hash)].map(c => c.charCodeAt(0))));
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d")!;
+  const imageData = ctx.createImageData(width, height);
+  imageData.data.set(rgba);
+  ctx.putImageData(imageData, 0, 0);
+  return canvas.toDataURL("image/png");
+}
+
+async function getImageThumbnail(imageUrl: string, {maxSize, opaque}: {maxSize: number, opaque: boolean}): Promise<{rgba: Uint8Array, w: number, h: number}> {
+  const image = await loadImage(imageUrl);
+  const width = image.width;
+  const height = image.height;
+
+  const scale = Math.min(maxSize / width, maxSize / height);
+  const resizedWidth = Math.floor(width * scale);
+  const resizedHeight = Math.floor(height * scale);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = resizedWidth;
+  canvas.height = resizedHeight;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Could not get canvas context");
+
+  if (opaque) {
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, resizedWidth, resizedHeight);
+  }
+  ctx.drawImage(image, 0, 0, resizedWidth, resizedHeight);
+
+  const imageData = ctx.getImageData(0, 0, resizedWidth, resizedHeight);
+  const rgba = new Uint8Array(imageData.data.buffer);
+  return {rgba, w: resizedWidth, h: resizedHeight};
+}

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -3,9 +3,9 @@
 /// <reference lib="webworker" />
 import OpenSCAD from "../wasm/openscad.js";
 
-import { createEditorFS, getParentDir, symlinkLibraries } from "../fs/filesystem.ts";
+import { createEditorFS, symlinkLibraries } from "../fs/filesystem.ts";
 import { OpenSCADInvocation, OpenSCADInvocationCallback, OpenSCADInvocationResults } from "./openscad-runner.ts";
-import { deployedArchiveNames, zipArchives } from "../fs/zip-archives.ts";
+import { deployedArchiveNames } from "../fs/zip-archives.ts";
 import { fetchSource } from "../utils.ts";
 
 importScripts("browserfs.min.js");

--- a/src/state/app-state.ts
+++ b/src/state/app-state.ts
@@ -35,6 +35,12 @@ export interface State {
     extruderColors?: string[],
   },
 
+  
+  preview?: {
+    thumbhash?: string,
+    blurhash?: string,
+  },
+
   view: {
     logs?: boolean,
     extruderPickerVisibility?: 'editing' | 'exporting',

--- a/src/state/fragment-state.ts
+++ b/src/state/fragment-state.ts
@@ -42,7 +42,8 @@ async function decompressString(compressedInput: string): Promise<string> {
 export function encodeStateParamsAsFragment(state: State) {
   const json = JSON.stringify({
     params: state.params,
-    view: state.view
+    view: state.view,
+    preview: state.preview,
   });
   // return encodeURIComponent(json);
   return compressString(json);
@@ -73,7 +74,7 @@ export async function readStateFromFragment(): Promise<State | null> {
         // Backwards compatibility
         obj = JSON.parse(decodeURIComponent(serialized));
       }
-      const {params, view} = obj;
+      const {params, view, preview} = obj;
       return {
         params: {
           activePath: validateString(params?.activePath, () => defaultSourcePath),
@@ -85,6 +86,10 @@ export async function readStateFromFragment(): Promise<State | null> {
           exportFormat3D: validateStringEnum(params?.exportFormat3D, Object.keys(VALID_EXPORT_FORMATS_3D), s => 'glb'),
           extruderColors: validateArray(params?.extruderColors, validateString, () => undefined as any as []),
         },
+        preview: preview ? {
+          thumbhash: preview.thumbhash ? validateString(preview.thumbhash) : undefined,
+          blurhash: preview.blurhash ? validateString(preview.blurhash) : undefined,
+        } : undefined,
         view: {
           logs: validateBoolean(view?.logs),
           extruderPickerVisibility: validateStringEnum(view?.extruderPickerVisibility, ['editing', 'exporting'], s => undefined),

--- a/src/state/initial-state.ts
+++ b/src/state/initial-state.ts
@@ -6,8 +6,9 @@ import { fetchSource } from '../utils';
 
 export const defaultSourcePath = '/playground.scad';
 export const defaultModelColor = '#f9d72c';
+const defaultBlurhash = "|KSPX^%3~qtjMx$lR*x]t7n,R%xuxbM{WBt7ayfk_3bY9FnAt8XOxanjNF%fxbMyIn%3t7NFoLaeoeV[WBo{xar^IoS1xbxcR*S0xbofRjV[j[kCNGofxaWBNHW-xasDR*WTkBxuWBM{s:t7bYahRjfkozWUadofbIW:jZ";
   
-export async function createInitialState(state: State | null, source?: {content?: string, path?: string, url?: string}): Promise<State> {
+export async function createInitialState(state: State | null, source?: {content?: string, path?: string, url?: string, blurhash?: string}): Promise<State> {
 
   type Mode = State['view']['layout']['mode'];
   const mode: Mode = window.matchMedia("(min-width: 768px)").matches 
@@ -18,14 +19,16 @@ export async function createInitialState(state: State | null, source?: {content?
     if (source) throw new Error('Cannot provide source when state is provided');
     initialState = state;
   } else {
-    let content, path, url;
+    let content, path, url, blurhash;
     if (source) {
       content = source.content;
       path = source.path;
       url = source.url;
+      blurhash = source.blurhash;
     } else {
       content = defaultScad;
       path = defaultSourcePath;
+      blurhash = defaultBlurhash;
     }
     let activePath = path ?? (url && new URL(url).pathname.split('/').pop()) ?? defaultSourcePath;
     initialState = {
@@ -46,6 +49,7 @@ export async function createInitialState(state: State | null, source?: {content?
 
         color: defaultModelColor,
       },
+      preview: blurhash ? {blurhash} : undefined,
     };
   }
 

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -142,6 +142,11 @@ export class Model {
         s.lastCheckerRun = undefined;
         s.output = undefined;
         s.export = undefined;
+        s.preview = undefined;
+        s.currentRunLogs = undefined;
+        s.error = undefined;
+        s.is2D = undefined;
+        console.log('Opened file:', path);
       }
     })) {
       this.processSource();


### PR DESCRIPTION
Computing a [Blurhash](https://blurha.sh/) after each render & store it in the state / hash fragment, available when refreshing page (or loading from URL)

![image](https://github.com/user-attachments/assets/48d0a4a3-1fd2-476d-bd47-a6ad1dc83632)


Also, small fixes:
- Strip extra whitespace in multimaterial dialog
- Fix storage regression from webpack update