### PR TITLE
Disable Monaco editor on Android user agents

### DIFF
--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -17,7 +17,8 @@ import FilePicker, {  } from './FilePicker.tsx';
 const isMonacoSupported = (() => {
   const ua = window.navigator.userAgent;
   const iosWk = ua.match(/iPad|iPhone/i) && ua.match(/WebKit/i);
-  return !iosWk;
+  const android = ua.match(/Android/i);
+  return !(iosWk || android);
 })();
 
 let monacoInstance: Monaco | null = null;


### PR DESCRIPTION
## Description
Disables the Monaco editor on Android user agents, matching the existing workaround for iOS/WebKit.
Monaco Editor does not officially support mobile browsers, and causes usability issues on Android.

## Related issue
Closes #138

## Type of change
- [x] Bug fix
- [x] Other: compatibility workaround for mobile browsers

## How to test
1. Open OpenSCAD Playground on an Android device.
2. Verify that the non-Monaco editor is used.
3. Confirm code editing works.
4. Desktop browsers continue to use Monaco.