### PR TITLE
fix: auto-convert GitHub blob URLs and strip line anchors in #url= handler

### DIFF
--- a/src/components/CustomizerPanel.tsx
+++ b/src/components/CustomizerPanel.tsx
@@ -116,7 +116,7 @@ function ParameterInput({param, value, className, style, handleChange}: {param: 
           {param.type === 'number' && 'options' in param && (
             <Dropdown
               style={{flex: 1}}
-              value={value || param.initial}
+              value={value ?? param.initial}
               options={param.options}
               onChange={(e) => handleChange(param.name, e.value)}
               optionLabel="name"
@@ -125,7 +125,7 @@ function ParameterInput({param, value, className, style, handleChange}: {param: 
           )}
           {param.type === 'string' && param.options && (
             <Dropdown
-              value={value || param.initial}
+              value={value ?? param.initial}
               options={param.options}
               onChange={(e) => handleChange(param.name, e.value)}
               optionLabel="name"
@@ -140,7 +140,7 @@ function ParameterInput({param, value, className, style, handleChange}: {param: 
           )}
           {!Array.isArray(param.initial) && param.type === 'number' && !('options' in param) && (
             <InputNumber
-              value={value || param.initial}
+              value={value ?? param.initial}
               showButtons
               size={5}
               onValueChange={(e) => handleChange(param.name, e.value)}
@@ -149,7 +149,7 @@ function ParameterInput({param, value, className, style, handleChange}: {param: 
           {param.type === 'string' && !param.options && (
             <InputText
               style={{flex: 1}}
-              value={value || param.initial}
+              value={value ?? param.initial}
               onChange={(e) => handleChange(param.name, e.target.value)}
             />
           )}
@@ -196,7 +196,7 @@ function ParameterInput({param, value, className, style, handleChange}: {param: 
             minHeight: '5px',
             margin: '5px 40px 5px 5px',
           }}
-          value={value || param.initial}
+          value={value ?? param.initial}
           min={param.min}
           max={param.max}
           step={param.step}

--- a/src/state/fragment-state.ts
+++ b/src/state/fragment-state.ts
@@ -61,7 +61,10 @@ export async function readStateFromFragment(): Promise<State | null> {
         return createInitialState(null, {path}); 
       } else if (serialized.startsWith('url=')) {
         // For testing
-        const url = decodeURIComponent(serialized.substring('url='.length));
+        const rawUrl = decodeURIComponent(serialized.substring('url='.length));
+        const url = rawUrl
+          .split('#')[0]
+          .replace(/^https:\/\/github\.com\/(.+)\/blob\/(.+)$/, 'https://raw.githubusercontent.com/$1/$2');
         const path = '/' + new URL(url).pathname.split('/').pop();
         return createInitialState(null, {path, url});
       }


### PR DESCRIPTION
## Changes

### Fix 1 — Fixes #57
Auto-converts GitHub blob URLs in `#url=` handler:
- `github.com/.../blob/...` → `raw.githubusercontent.com`
- Strips line anchors like `#L5` before fetching

### Fix 2 — Fixes #106
Replace `||` with `??` for dropdown values in CustomizerPanel:
- `||` fails when value is `0` or `false`
- `??` only falls back when value is `null` or `undefined`
- Fixes labeled dropdowns not showing selected value correctly